### PR TITLE
add CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rusty editor
 
-Scene editor for [rg3d engine](https://github.com/mrDIMAS/rg3d).
+[![CI Status](https://github.com/gideongrinberg/rusty-editor/actions/workflows/ci.yml/badge.svg)](https://github.com/gideongrinberg/rusty-editor/actions/workflows/ci.yml)
 
 ## Motivation
 
@@ -58,7 +58,7 @@ use rg3d::scene::Scene;
 let mut scene = Scene::default();
 
 // There is no difference between scene created in rusty-editor and any other
-// model file, so any scene can be used directly as resource. 
+// model file, so any scene can be used directly as resource.
 let root = resource_manager
 	.request_model("your_scene.rgs")
 	.unwrap()
@@ -66,9 +66,9 @@ let root = resource_manager
 	.unwrap()
 	.instantiate(&mut scene)
 	.root;
-	
+
 let scene_handle = engine.scenes.add(scene);
-	
+
 ```
 
 Alternatively `rgs` can be loaded by `Scene::from_file` method:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # rusty editor
 
-[![CI Status](https://github.com/gideongrinberg/rusty-editor/actions/workflows/ci.yml/badge.svg)](https://github.com/gideongrinberg/rusty-editor/actions/workflows/ci.yml)
+Scene editor for [rg3d engine](https://github.com/rg3dengine/rg3d).
+
+[![CI Status](https://github.com/rg3dengine/rusty-editor/actions/workflows/ci.yml/badge.svg)](https://github.com/rg3dengine/rusty-editor/actions/workflows/ci.yml)
 
 ## Motivation
 

--- a/ci.yml
+++ b/ci.yml
@@ -38,6 +38,14 @@ jobs:
     - name: Test
       run: cargo test --verbose
 
+  wasm:
+    name: Wasm CI
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Dependencies and tools
+      run: sudo apt-get install libasound2-dev libudev-dev pkg-config; rustup target add wasm32-unknown-unknown; cargo install wasm-pack; cargo install basic-http-server
+    - uses: actions/checkout@v2
+    -
   # MacOS 11 CI is currently in beta. Uncomment the below lines when it's out of beta.
   # macos11:
   #   name: MacOS Big Sur (M1) CI

--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+on: [push, pull_request]
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  windows:
+    name: Windows CI
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo check --verbose
+    - name: Test
+      run: cargo test --verbose
+
+  macosx:
+    name: MacOSX CI
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo check --verbose
+    - name: Test
+      run: cargo test --verbose
+
+  linux:
+    name: Linux CI
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Dependencies
+      run: sudo apt-get install libasound2-dev libudev-dev pkg-config
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo check --verbose
+    - name: Test
+      run: cargo test --verbose
+
+  # MacOS 11 CI is currently in beta. Uncomment the below lines when it's out of beta.
+  # macos11:
+  #   name: MacOS Big Sur (M1) CI
+  #   runs-on: macos-11
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Build
+  #     run: cargo build --verbose
+  #   - name: Test
+  #     run: cargo test --verbose

--- a/ci.yml
+++ b/ci.yml
@@ -45,7 +45,10 @@ jobs:
     - name: Install Dependencies and tools
       run: sudo apt-get install libasound2-dev libudev-dev pkg-config; rustup target add wasm32-unknown-unknown; cargo install wasm-pack; cargo install basic-http-server
     - uses: actions/checkout@v2
-    -
+    - name: build
+      run: cargo check --verbose
+    - name: test
+      run: cargo test --verbose
   # MacOS 11 CI is currently in beta. Uncomment the below lines when it's out of beta.
   # macos11:
   #   name: MacOS Big Sur (M1) CI

--- a/ci.yml
+++ b/ci.yml
@@ -38,17 +38,6 @@ jobs:
     - name: Test
       run: cargo test --verbose
 
-  wasm:
-    name: Wasm CI
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install Dependencies and tools
-      run: sudo apt-get install libasound2-dev libudev-dev pkg-config; rustup target add wasm32-unknown-unknown; cargo install wasm-pack; cargo install basic-http-server
-    - uses: actions/checkout@v2
-    - name: build
-      run: cargo check --verbose
-    - name: test
-      run: cargo test --verbose
   # MacOS 11 CI is currently in beta. Uncomment the below lines when it's out of beta.
   # macos11:
   #   name: MacOS Big Sur (M1) CI


### PR DESCRIPTION
This PR adds CI and #19 closes . The CI currently checks and tests the codebase.

Checking it via cargo check essentially makes sure the code will compile without actually compiling it. It still takes a bit to run (10 mins), but that's mainly due to the fact that it's not using incremental compilation and the library is quite large.