### PR TITLE
Camera fix

### DIFF
--- a/src/menu.rs
+++ b/src/menu.rs
@@ -647,8 +647,9 @@ impl Menu {
                         )))
                         .unwrap();
                 } else if message.destination() == self.create_camera {
-                    let node =
-                        CameraBuilder::new(BaseBuilder::new().with_name("Camera")).build_node();
+                    let node = CameraBuilder::new(BaseBuilder::new().with_name("Camera"))
+                        .enabled(false)
+                        .build_node();
 
                     self.message_sender
                         .send(Message::DoSceneCommand(SceneCommand::AddNode(

--- a/src/scene/commands/camera.rs
+++ b/src/scene/commands/camera.rs
@@ -19,19 +19,19 @@ define_node_command!(SetZFarCommand("Set Camera Z Far", f32) where fn swap(self,
 
 #[derive(Debug)]
 pub struct SetCameraPreviewCommand {
-    node: Handle<Node>,
+    handle: Handle<Node>,
     value: bool,
     old_value: bool,
-    last_active: Vec<Handle<Node>>,
+    prev_active: Vec<Handle<Node>>,
 }
 
 impl SetCameraPreviewCommand {
     pub fn new(node: Handle<Node>, value: bool) -> Self {
         Self {
-            node,
+            handle: node,
             value,
             old_value: false,
-            last_active: Vec::new(),
+            prev_active: Vec::new(),
         }
     }
 }
@@ -44,52 +44,49 @@ impl<'a> Command<'a> for SetCameraPreviewCommand {
     }
 
     fn execute(&mut self, context: &mut Self::Context) {
-        let camera = context.scene.graph[self.node].as_camera_mut();
+        let camera = context.scene.graph[self.handle].as_camera_mut();
         self.old_value = camera.is_enabled();
         camera.set_enabled(self.value);
 
         let editor_camera_handle = context.editor_scene.camera_controller.camera;
+        let editor_camera = context.scene.graph[editor_camera_handle].as_camera_mut();
+        editor_camera.set_enabled(!self.value);
 
-        self.last_active = context
-            .scene
-            .graph
-            .pair_iter_mut()
-            .filter_map(|(handle, node)| {
-                if self.node == handle || editor_camera_handle == handle {
-                    return None;
-                }
-
-                if let Node::Camera(cam) = node {
-                    if cam.is_enabled() {
-                        cam.set_enabled(false);
-                        Some(handle)
+        // disable other cameras and save their handles to be able to revert
+        if self.value {
+            self.prev_active = context
+                .scene
+                .graph
+                .pair_iter_mut()
+                .filter(|(handle, _)| handle != &self.handle && handle != &editor_camera_handle)
+                .filter_map(|(handle, node)| {
+                    if let Node::Camera(cam) = node {
+                        if cam.is_enabled() {
+                            cam.set_enabled(false);
+                            Some(handle)
+                        } else {
+                            None
+                        }
                     } else {
                         None
                     }
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-
-        let editor_camera = context.scene.graph[editor_camera_handle].as_camera_mut();
-        editor_camera.set_enabled(!self.value);
+                })
+                .collect();
+        }
     }
 
     fn revert(&mut self, context: &mut Self::Context) {
-        for handle in self.last_active.iter_mut() {
+        for handle in self.prev_active.iter_mut() {
             let camera = context.scene.graph[*handle].as_camera_mut();
             camera.set_enabled(true);
         }
-        let camera = context.scene.graph[self.node].as_camera_mut();
+
+        let camera = context.scene.graph[self.handle].as_camera_mut();
         camera.set_enabled(self.old_value);
 
-        let editor_camera_node = context.editor_scene.camera_controller.camera;
-        let editor_camera = context.scene.graph[editor_camera_node].as_camera_mut();
-        if self.last_active.len() == 0 {
-            editor_camera.set_enabled(!self.old_value);
-        } else {
-            editor_camera.set_enabled(false);
-        }
+        let editor_camera_handle = context.editor_scene.camera_controller.camera;
+        let editor_camera = context.scene.graph[editor_camera_handle].as_camera_mut();
+        let editor_camera_enabled = !self.old_value && self.prev_active.is_empty();
+        editor_camera.set_enabled(editor_camera_enabled);
     }
 }

--- a/src/scene/commands/camera.rs
+++ b/src/scene/commands/camera.rs
@@ -16,3 +16,71 @@ define_node_command!(SetZNearCommand("Set Camera Z Near", f32) where fn swap(sel
 define_node_command!(SetZFarCommand("Set Camera Z Far", f32) where fn swap(self, node) {
     get_set_swap!(self, node.as_camera_mut(), z_far, set_z_far);
 });
+
+#[derive(Debug)]
+pub struct SetCameraPreviewCommand {
+    node: Handle<Node>,
+    value: bool,
+    old_value: bool,
+    last_active: Vec<Handle<Node>>,
+}
+
+impl SetCameraPreviewCommand {
+    pub fn new(node: Handle<Node>, value: bool) -> Self {
+        Self {
+            node,
+            value,
+            old_value: false,
+            last_active: Vec::new(),
+        }
+    }
+}
+
+impl<'a> Command<'a> for SetCameraPreviewCommand {
+    type Context = SceneContext<'a>;
+
+    fn name(&mut self, _context: &Self::Context) -> String {
+        "Set camera preview".to_owned()
+    }
+
+    fn execute(&mut self, context: &mut Self::Context) {
+        let camera = context.scene.graph[self.node].as_camera_mut();
+        self.old_value = camera.is_enabled();
+        camera.set_enabled(self.value);
+
+        self.last_active = context
+            .scene
+            .graph
+            .pair_iter_mut()
+            .filter_map(|(handle, node)| {
+                if let Node::Camera(cam) = node {
+                    if self.node != handle && cam.is_enabled() {
+                        cam.set_enabled(false);
+                        Some(handle)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let editor_camera_node = context.editor_scene.camera_controller.camera;
+        let editor_camera = context.scene.graph[editor_camera_node].as_camera_mut();
+        editor_camera.set_enabled(!self.value);
+    }
+
+    fn revert(&mut self, context: &mut Self::Context) {
+        for handle in self.last_active.iter_mut() {
+            let camera = context.scene.graph[*handle].as_camera_mut();
+            camera.set_enabled(true);
+        }
+        let camera = context.scene.graph[self.node].as_camera_mut();
+        camera.set_enabled(self.old_value);
+
+        let editor_camera_node = context.editor_scene.camera_controller.camera;
+        let editor_camera = context.scene.graph[editor_camera_node].as_camera_mut();
+        editor_camera.set_enabled(!self.old_value);
+    }
+}

--- a/src/scene/commands/mod.rs
+++ b/src/scene/commands/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     scene::{
         clipboard::DeepCloneResult,
         commands::{
-            camera::{SetFovCommand, SetZFarCommand, SetZNearCommand},
+            camera::{SetCameraPreviewCommand, SetFovCommand, SetZFarCommand, SetZNearCommand},
             graph::{
                 AddNodeCommand, DeleteNodeCommand, DeleteSubGraphCommand, LinkNodesCommand,
                 LoadModelCommand, MoveNodeCommand, RotateNodeCommand, ScaleNodeCommand,
@@ -193,6 +193,7 @@ pub enum SceneCommand {
     SetFov(SetFovCommand),
     SetZNear(SetZNearCommand),
     SetZFar(SetZFarCommand),
+    SetCameraActive(SetCameraPreviewCommand),
 
     // Particle system commands.
     SetParticleSystemAcceleration(SetParticleSystemAccelerationCommand),
@@ -332,6 +333,7 @@ macro_rules! static_dispatch {
             SceneCommand::SetFov(v) => v.$func($($args),*),
             SceneCommand::SetZNear(v) => v.$func($($args),*),
             SceneCommand::SetZFar(v) => v.$func($($args),*),
+            SceneCommand::SetCameraActive(v) => v.$func($($args),*),
             SceneCommand::SetParticleSystemAcceleration(v) => v.$func($($args),*),
             SceneCommand::AddParticleSystemEmitter(v) => v.$func($($args),*),
             SceneCommand::SetEmitterNumericParameter(v) => v.$func($($args),*),


### PR DESCRIPTION
Added "preview" checkbox in `CameraSection` (#12). If it's checked we disable every other camera and enable the only we checked.
Also we store previously enabled cameras within the executed command to be able to undo changes.
If the checkbox was unchecked, we disable the camera and enable editor camera.