### PR TITLE
rephrase message about working directory location to make it less confusing

### DIFF
--- a/src/configurator.rs
+++ b/src/configurator.rs
@@ -113,8 +113,8 @@ impl Configurator {
             .collect::<Vec<_>>();
 
         let message = "Please select the working directory of \
-        your current project. In most cases it will be the place where \
-        the binary of your project is located.";
+        your current project. In most cases it will be the root folder \
+        of your project";
 
         let lv_history;
         let window = WindowBuilder::new(


### PR DESCRIPTION
phrase *"the place where the binary of your project is located"* that is shown when **rusty editor** is opened is a bit confusing, because "binary of your project" sounds like an `my_game.exe` file generated by rustc which is not the place that we want to place our scenes at.